### PR TITLE
Changes how the product id is passed

### DIFF
--- a/src/app/controllers/FileController.js
+++ b/src/app/controllers/FileController.js
@@ -9,7 +9,7 @@ class FileController {
 
   async store(req, res) {
     const { originalname: name, filename: path } = req.file;
-    const { product_id } = req.body;
+    const product_id = req.params.id;
 
     const product = await Product.findOne({ where: { id: product_id } });
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -27,6 +27,6 @@ routes.get('/products/:id', ProductController.index);
 routes.post('/products', ProductController.store);
 
 routes.get('/files', FileController.index);
-routes.post('/files', upload.single('file'), FileController.store);
+routes.post('/files/products/:id', upload.single('file'), FileController.store);
 
 export default routes;


### PR DESCRIPTION
Instead of /api/files, passing the product id in the multipart form, it becomes /api/files/products/${product_id}.